### PR TITLE
Update Headlamp status

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -10666,9 +10666,12 @@ landscape:
             repo_url: https://github.com/kubernetes-sigs/headlamp
             logo: headlamp.svg
             twitter: https://twitter.com/headlamp_ui
+            bluesky_url: https://bsky.app/profile/headlamp.dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2023-05-17'
+              blog_url: https://headlamp.dev/blog
+              slack_url: https://kubernetes.slack.com/messages/headlamp
               clomonitor_name: headlamp
               dev_stats_url: https://headlamp.devstats.cncf.io/
           - item:

--- a/landscape.yml
+++ b/landscape.yml
@@ -10663,7 +10663,7 @@ landscape:
             name: Headlamp
             description: Extensible open source multi-cluster Kubernetes user interface
             homepage_url: https://headlamp.dev
-            repo_url: https://github.com/headlamp-k8s/headlamp
+            repo_url: https://github.com/kubernetes-sigs/headlamp
             logo: headlamp.svg
             twitter: https://twitter.com/headlamp_ui
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation

--- a/landscape.yml
+++ b/landscape.yml
@@ -10663,7 +10663,6 @@ landscape:
             name: Headlamp
             description: Extensible open source multi-cluster Kubernetes user interface
             homepage_url: https://headlamp.dev
-            project: sandbox
             repo_url: https://github.com/headlamp-k8s/headlamp
             logo: headlamp.svg
             twitter: https://twitter.com/headlamp_ui


### PR DESCRIPTION
In April Headlamp joined the Kubernetes SIG UI and we have been slowly changing the existing info about the project.
Since Headlamp's info in the landscape was still outdated, this PR intends to bring it up to date.
One thing it's not clear is whether I should update the _project_ as being graduated, since it's considered as such now.

I appreciate any guidance here.

